### PR TITLE
Changed vertx-core scope to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
             <version>${vertx.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!--Test dependencies-->


### PR DESCRIPTION
Change the scope to provided so the project can define it's own vertx version
